### PR TITLE
Include tushare.internet in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,6 @@ setup(
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'License :: OSI Approved :: BSD License'],
-    packages=['tushare','tushare.stock', 'tushare.data', 'tushare.util', 'tushare.datayes'],
+    packages=['tushare','tushare.stock', 'tushare.data', 'tushare.util', 'tushare.datayes', 'tushare.internet'],
     package_data={'': ['*.csv']},
 )


### PR DESCRIPTION
I'm setup from github directly and found 'import tushare' will reports error 'tushare.internet missing'.
Guess it's missed in setup.py when adding new feature.
