### PR TITLE
newsinfobytime 把newsPublishDate 写了两次,这里接口报错

### DIFF
--- a/tushare/util/vars.py
+++ b/tushare/util/vars.py
@@ -470,7 +470,7 @@ SOCIALDATAXQBYTICKER = '/api/subject/getSocialDataXQByTicker.csv?ticker=%s&field
 SOCIALDATAXQBYDATE = '/api/subject/getSocialDataXQByDate.csv?statisticsDate=%s&field=%s'
 OPTVAR = '/api/options/getOptVar.csv?exchangeCD=%s&secID=%s&ticker=%s&contractType=%s&exerType=%s&field=%s'
 NEWSINFO = '/api/subject/getNewsInfo.csv?newsID=%s&field=%s'
-NEWSINFOBYTIME = '/api/subject/getNewsInfoByTime.csv?newsPublishDate=%s&newsPublishDate=%s&beginTime=%s&endTime=%s&field=%s'
+NEWSINFOBYTIME = '/api/subject/getNewsInfoByTime.csv?newsPublishDate=%s&beginTime=%s&endTime=%s&field=%s'
 NEWSCONTENT = '/api/subject/getNewsContent.csv?newsID=%s&field=%s'
 NEWSCONTENTBYTIME = '/api/subject/getNewsContentByTime.csv?newsPublishDate=%s&newsPublishDate=%s&beginTime=%s&endTime=%s&field=%s'
 COMPANYBYNEWS = '/api/subject/getCompanyByNews.csv?newsID=%s&field=%s'


### PR DESCRIPTION
  File "/Library/Python/2.7/site-packages/tushare/datayes/subject.py", line 57, in NewsInfoByTime
    code, result = self.client.getData(vs.NEWSINFOBYTIME%(newsPublishDate, beginTime, endTime, field))
TypeError: not enough arguments for format string

NEWSINFOBYTIME = '/api/subject/getNewsInfoByTime.csv?newsPublishDate=%s&newsPublishDate=%s&beginTime=%s&endTime=%s&field=%s'

相同的参数还有 NEWSCONTENTBYTIME = '/api/subject/getNewsContentByTime.csv?newsPublishDate=%s&newsPublishDate=%s&beginTime=%s&endTime=%s&field=%s'

未测试