### PR TITLE
解决sort is deprecated #70问题

### DIFF
--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -438,7 +438,7 @@ def get_h_data(code, start=None, end=None, autype='qfq',
                 data = data.drop('factor', axis=1)
             df = _parase_fq_factor(code, start, end)
             df = df.drop_duplicates('date')
-            df = df.sort('date', ascending=False)
+            df = df.sort_values('date', ascending=False)
             firstDate = data.head(1)['date']
             frow = df[df.date == firstDate[0]]
             rt = get_realtime_quotes(code)


### PR DESCRIPTION
使用sort_values代替即将失效的pandas sort函数。
https://github.com/waditu/tushare/issues/70