### PR TITLE
_code_to_symbol函数改进

### DIFF
--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -624,7 +624,7 @@ def _code_to_symbol(code):
     if code in ct.INDEX_LABELS:
         return ct.INDEX_LIST[code]
     else:
-        if len(code) != 6 :
-            return ''
-        else:
+        if len(code) == 6 :
             return 'sh%s'%code if code[:1] in ['5', '6', '9'] else 'sz%s'%code
+        else:
+            return code

--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -624,7 +624,7 @@ def _code_to_symbol(code):
     if code in ct.INDEX_LABELS:
         return ct.INDEX_LIST[code]
     else:
-        if len(code) == 6 :
+        if 6 == len(code):
             return 'sh%s'%code if code[:1] in ['5', '6', '9'] else 'sz%s'%code
         else:
-            return code
+            return code.lower()


### PR DESCRIPTION
get_realtime_quotes中对代码进行假设判断，自动加上了“sz”和“sh”，但是形如"sh000068"则无法通过此接口获得。
对_code_to_symbol函数进行修改，对于长度不为6的股票代码，不修改直接返回。
这样可以使用：
get_realtime_quotes('sh000068')
get_realtime_quotes('SH000068')