### PR TITLE
DataFrame.sort方法替换 适用于pandas v0.17.0版本以及之后

### DIFF
--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -441,7 +441,7 @@ def get_h_data(code, start=None, end=None, autype='qfq',
                 data = data.drop('factor', axis=1)
             df = _parase_fq_factor(code, start, end)
             df = df.drop_duplicates('date')
-            df = df.sort('date', ascending=False)
+            df = df.sort_values(by="date", ascending=False)
             firstDate = data.head(1)['date']
             frow = df[df.date == firstDate[0]]
             rt = get_realtime_quotes(code)


### PR DESCRIPTION
在pandas v0.17.0 以后
* DataFrame.sort(columns=...)	 替换为 DataFrame.sort_values(by=...)
否则会产生警告