### PR TITLE
修复get_today_all 翻页问题

### DIFF
--- a/tushare/stock/cons.py
+++ b/tushare/stock/cons.py
@@ -16,7 +16,7 @@ INDEX_LABELS = ['sh', 'sz', 'hs300', 'sz50', 'cyb', 'zxb', 'zx300', 'zh500']
 INDEX_LIST = {'sh': 'sh000001', 'sz': 'sz399001', 'hs300': 'sz399300',
               'sz50': 'sh000016', 'zxb': 'sz399005', 'cyb': 'sz399006', 'zx300': 'sz399008', 'zh500':'sh000905'}
 P_TYPE = {'http': 'http://', 'ftp': 'ftp://'}
-PAGE_NUM = [38, 60, 80, 100]
+PAGE_NUM = [100, 60, 80, 100]
 FORMAT = lambda x: '%.2f' % x
 FORMAT4 = lambda x: '%.4f' % x
 DOMAINS = {'sina': 'sina.com.cn', 'sinahq': 'sinajs.cn',

--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -294,6 +294,8 @@ def get_today_all():
     if df is not None:
         for i in range(2, ct.PAGE_NUM[0]):
             newdf = _parsing_dayprice_json(i)
+            if newdf.empty:
+                break
             df = df.append(newdf, ignore_index=True)
     return df
 


### PR DESCRIPTION
get_today_all默认是38页，随着新股增发，已经超过了38页，所以我把PAGE_NUM[0]设置为100，然后在get_today_all  循环获取数据时判断返回的pandas是否为空，如果为空能break停止循环。