### PR TITLE
修改 setup.py 添加 install_requires 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 lxml == 3.4.4
+pandas
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from setuptools import setup, find_packages
 import codecs
 import os
-import tushare
+# import tushare
+exec(open('tushare/version.py').read())
+
 
 def read(fname):
     return codecs.open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -65,23 +67,28 @@ return::
 
 setup(
     name='tushare',
-    version=tushare.__version__,
+    version=__version__,
     description='A utility for crawling historical and Real-time Quotes data of China stocks',
-#     long_description=read("READM.rst"),
-    long_description = long_desc,
+    #     long_description=read("READM.rst"),
+    long_description=long_desc,
     author='Jimmy Liu',
     author_email='jimmysoa@sina.cn',
     license='BSD',
     url='http://tushare.org',
     keywords='China stock data',
+    install_requires=[
+        'lxml',
+        'pandas',
+        'requests',
+    ],
     classifiers=['Development Status :: 4 - Beta',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
-    'License :: OSI Approved :: BSD License'],
-    packages=['tushare','tushare.stock', 'tushare.data', 'tushare.util', 'tushare.datayes',
+                 'Programming Language :: Python :: 2.6',
+                 'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3.2',
+                 'Programming Language :: Python :: 3.3',
+                 'Programming Language :: Python :: 3.4',
+                 'License :: OSI Approved :: BSD License'],
+    packages=['tushare', 'tushare.stock', 'tushare.data', 'tushare.util', 'tushare.datayes',
               'tushare.internet', 'tushare.fund', 'tushare.trader', 'tushare.futures'],
     package_data={'': ['*.csv']},
 )

--- a/tushare/__init__.py
+++ b/tushare/__init__.py
@@ -1,5 +1,3 @@
-__version__ = '0.6.5'
-__author__ = 'Jimmy Liu'
 """
 for trading data
 """

--- a/tushare/version.py
+++ b/tushare/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.6.5'
+__author__ = 'Jimmy Liu'


### PR DESCRIPTION
update setup.py & requirement for pip install
* 用户使用 `pip install tushare` 一般是不能一次成功的，requirement.txt 里只写明 lxml 也不能保证安装一次生效
* 在 build `tushare` 之前不应该 `import` 任何 `tushare` 里的代码；重新整理了下 `setup.py`, 把 version 信息放在另外一个 `version.py` 中，添加了 `install-requires`, 这样在 `pip install` 的时候就能把相关依赖都拉取下来  
