### PR TITLE
修正ts.get_k_data

### DIFF
--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -676,7 +676,8 @@ def get_k_data(code=None, start='', end='',
                            ignore_index=True)
     if ktype not in ct.K_MIN_LABELS:
         if ((start is not None) & (start != '')) & ((end is not None) & (end != '')):
-            data = data[(data.date >= start) & (data.date <= end)]
+            if data.empty==False:       
+                data = data[(data.date >= start) & (data.date <= end)]
     return data
     raise IOError(ct.NETWORK_URL_ERROR_MSG)
     


### PR DESCRIPTION
例如ts.get_k_data(code='601206',start='2015-11-01'),如果不加这个判断，会抛异常说data没有date属性（因为data为空DataFrame）
实际上你不需要抛异常，只用把这个空的df返回即可