### PR TITLE
A sub-package for processing data from the investor relationship platforms

### DIFF
--- a/test/investor_relations_test.py
+++ b/test/investor_relations_test.py
@@ -1,0 +1,24 @@
+
+import unittest
+import tushare as ts
+
+
+class Test(unittest.TestCase):
+    def test_grab_from_sz_replied(self):
+        df = ts.investor_relations.grab_from_sz_replied("000001")
+        df.to_csv("SZ000001_replied.csv", encoding="utf-8")
+
+    def test_grab_from_sz_all(self):
+        df = ts.investor_relations.grab_from_sz_all("000001")
+        df.to_csv("SZ000001_all.csv", encoding="utf-8")
+
+    def test_grab_from_sh_replied(self):
+        df = ts.investor_relations.grab_from_sh_replied("601398")
+        df.to_csv("SH601398_replied.csv", encoding="utf-8")
+
+    def test_grab_from_sh_unreplied(self):
+        df = ts.investor_relations.grab_from_sh_unreplied("601398")
+        df.to_csv("SH601398_unreplied.csv", encoding="utf-8")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tushare/__init__.py
+++ b/tushare/__init__.py
@@ -109,3 +109,9 @@ from tushare.stock.globals import (global_realtime)
 
 
 from tushare.util.mailmerge import (MailMerge)
+
+"""
+for investor relations database API
+"""
+
+from tushare.investor_relations import (grab_from_sh_unreplied, grab_from_sh_replied, grab_from_sz_all, grab_from_sz_replied)

--- a/tushare/investor_relations/GrabSH.py
+++ b/tushare/investor_relations/GrabSH.py
@@ -1,0 +1,96 @@
+import urllib.request
+import pandas as pd
+from bs4 import BeautifulSoup  # BS processes unicode much better
+
+__max_page_number = 100
+
+
+def __grab_from_sh(url_string, stock_code):
+
+    global __max_page_number
+
+    page_no = 1
+    qa_item_count = 0
+    qa_list = []
+
+    while True:
+        # Notes:
+        # 1. There seems to be currently no way of knowing how many pages there are except for enumerating until error.
+        # 2. There is only month and day but no year data available.
+        #
+        print("Processing page {0}...".format(str(page_no)))
+
+        request = urllib.request.Request(url_string.format(stock_code[(3 if stock_code[2] == "0" else 2):], str(page_no)))
+
+        #
+        # Set up request header for AJAX/XMLHttp request
+        #
+        request.add_header('Content-Type', 'application/json; charset=utf-8')
+        request.add_header('X-Requested-With', 'XMLHttpRequest')
+        request.add_header("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0")
+
+        response = urllib.request.urlopen(request)
+        html_doc = response.read().decode()
+
+        if html_doc.find("暂时没有") != -1:
+            break
+        if page_no > __max_page_number:  # Put some boundaries here in case rules change....
+            print("Page number exceeds {}".format(__max_page_number))
+            print("There is either something wrong, or you can set the __max_page_number to a lager value to proceed.")
+            break
+
+        soup = BeautifulSoup(html_doc, "lxml")
+
+        feed_item_tags = soup.find_all(class_="m_feed_item")
+
+        for tag in feed_item_tags:
+            try:
+                date = tag.div.find_all(class_="m_feed_from")[0].span.string
+                question = list(tag.div.find_all(class_="m_feed_txt")[0].strings)[2].strip()
+            except IndexError:
+                try:
+                    date = tag.find_all(class_="m_feed_from")[0].span.string
+                    question = list(tag.find_all(class_="m_feed_txt")[0].strings)[2].strip()
+                except Exception:
+                    print("Error processing tag:")
+                    print(tag)
+            try:
+                answer = tag.div.next_sibling.next_sibling.next_sibling.next_sibling.find_all(class_="m_feed_txt")[0].string.strip()
+            except Exception:
+                answer = ""
+
+            qa_list.append((date, question, answer))
+            qa_item_count += 1
+
+        page_no += 1
+
+    return pd.DataFrame(qa_list, columns=["Date", "Question", "Answer"])
+
+
+def grab_from_sh_replied(stock_code):
+    """
+    Grab replied Q&A items from the Shanghai stock exchange investor relations website (http://sns.sseinfo.com).
+    This is mapped to the "最新答复" section of sns.sseinfo.com.
+    :param stock_code: the stock code in string
+    :return: A pandas DataFrame object containing date, question and answer.
+    *The sseinfo.com website doesn't have year information of the Q&A date.
+    """
+    url_string = r"http://sns.sseinfo.com/ajax/userfeeds.do?typeCode=company&type=11&pageSize=10&uid={}&page={}"
+    return __grab_from_sh(url_string, stock_code)
+
+
+def grab_from_sh_unreplied(stock_code):
+    """
+    Grab unreplied Q&A items from the Shanghai stock exchange investor relations website (http://sns.sseinfo.com).
+    This is mapped to the "最新提问" section of sns.sseinfo.com.
+    :param stock_code: the stock code in string
+    :return: A pandas DataFrame object containing date, question and answer.
+    *The sseinfo.com website doesn't have year information of the Q&A date.
+    """
+    url_string = r"http://sns.sseinfo.com/ajax/userfeeds.do?typeCode=company&type=10&pageSize=10&uid={}&page={}"
+    return __grab_from_sh(url_string, stock_code)
+
+
+def set_max_page_number(page_no):
+    global __max_page_number
+    __max_page_number = page_no

--- a/tushare/investor_relations/GrabSZ.py
+++ b/tushare/investor_relations/GrabSZ.py
@@ -1,0 +1,96 @@
+import urllib.request
+import re
+from bs4 import BeautifulSoup  # BS processes unicode much better
+import pandas as pd
+import datetime
+
+
+def __convert_chinese_date(date_string):
+    "Converts chinese date text to python datetime object"
+    return datetime.datetime(year=int(date_string[:4]), month=int(date_string[5:7]), day=int(date_string[8:10]))
+
+
+def __process_page(url):
+
+    soup = BeautifulSoup(urllib.request.urlopen(url), "lxml")
+    question_tags = soup.find_all(class_="ask")
+    question_items = [None] * len(question_tags)  # Pre-allocate memory space so we don't have to call append so often
+    idx = 0
+    for tag in question_tags:
+        question_items[idx] = tag["href"]
+        idx += 1
+    base_url = url[:url.rfind("/") + 1]
+
+    qa_list = [None] * len(question_tags)  # Again, pre-allocate memory for the list
+    idx = 0
+    for itm in question_items:
+        sub_question_url = base_url + itm
+        sub_soup = BeautifulSoup(urllib.request.urlopen(sub_question_url), "lxml")
+        date_tags = sub_soup.find_all(class_="date")
+        question_date = __convert_chinese_date(date_tags[0].string)
+        msg_contents = sub_soup.find_all(class_="msgCnt")
+        question = list(msg_contents[0].div.strings)[-1].strip()
+        #
+        # Couple of things to note for the answer block:
+        # 1) No sub <div>.
+        # 2) <br> inserted as hard line-break - this is interpreted as separate string items. Apparently, the company's IR uses a
+        # different system.
+        #
+        if len(msg_contents) > 1:
+            answer_block_text_list = list(msg_contents[1].strings)
+            if len(answer_block_text_list) >= 4:
+                answer = "".join(answer_block_text_list[4:]).strip()
+                if len(answer) > 0:
+                    answer = answer[1:]  # Do some prettify of the result...
+                    answer = answer.strip()
+        else:
+            answer = ""
+
+        qa_list[idx] = (question_date, question, answer)
+        idx += 1
+
+    return qa_list
+
+
+def __grab_from_sz(url_string, stock_code):
+    market_code = "S"
+    page_no = 1
+
+    soup = BeautifulSoup(urllib.request.urlopen(url_string.format(stock_code, market_code, page_no)), "lxml")
+    pages_td = soup.find_all(class_="PagesBox").pop().table.tbody.tr.next_sibling.td  # Locate the pages box
+    pages_match = re.findall("\(\d+\)", str(pages_td))  # Find all the page number quotes
+
+    # Find the maximum page number
+    max_page_num = 0
+    for page_num in map(lambda s: s.lstrip("(").rstrip(")"), pages_match):
+        if int(page_num) >= max_page_num:
+            max_page_num = int(page_num)
+
+    qa_list = []
+    for page_idx in range(1, max_page_num + 1):
+        print("Processing page {} of {}...".format(page_idx, max_page_num))
+        qa_list += __process_page(url_string.format(stock_code, market_code, page_idx))
+
+    return pd.DataFrame(qa_list, columns=["Date", "Question", "Answer"])
+
+
+def grab_from_sz_replied(stock_code):
+    """
+     Grab replied Q&A data from the Shenzhen stock exchange investor relations website (http://irm.cninfo.com.cn).
+     This is mapped to the "最新答复" section of irm.cninfo.com.
+     :param stock_code: the stock code in string
+     :return: A pandas DataFrame object containing date, question and answer.
+     """
+    url_string = r"http://irm.cninfo.com.cn/ircs/interaction/lastRepliesforSzseSsgs.do?condition.type=1&condition.stockcode={}&condition.stocktype={}&pageNo={}"
+    return __grab_from_sz(url_string, stock_code)
+
+
+def grab_from_sz_all(stock_code):
+    """
+     Grab all Q&A data from the Shenzhen stock exchange investor relations website (http://irm.cninfo.com.cn).
+     This is mapped to the "最新提问" section of irm.cninfo.com.
+     :param stock_code: the stock code in string
+     :return: A pandas DataFrame object containing date, question and answer.
+     """
+    url_string = r"http://irm.cninfo.com.cn/ircs/interaction/lastQuestionforSzseSsgs.do?condition.type=2&condition.stockcode={}&condition.stocktype={}&pageNo={}"
+    return __grab_from_sz(url_string, stock_code)

--- a/tushare/investor_relations/__init__.py
+++ b/tushare/investor_relations/__init__.py
@@ -1,0 +1,11 @@
+from .GrabSH import grab_from_sh_replied
+from .GrabSH import grab_from_sh_unreplied
+from .GrabSH import set_max_page_number
+from .GrabSZ import grab_from_sz_replied
+from .GrabSZ import grab_from_sz_all
+
+
+__all__ = ("grab_from_sh_unreplied", "grab_from_sh_replied", "grab_from_sz_replied", "grab_from_sz_all", "set_max_page_number")
+
+if __name__ == "__main__":
+    print("Module to grab Q&A data from Shanghai and Shenzhen stock exchange investor relations database.")


### PR DESCRIPTION
Added a sub-package for tushare to get question and answer data from the investor relationship communication platforms of SZ & SH stock exchanges (irm.cninfo.com and sns.sseinfo.com).

Can be used to track trends, e.g., below shows the wordcloud of Le Network, generated from the investor relationship data.

![figure_1](https://cloud.githubusercontent.com/assets/18495787/25571680/b6edef9a-2e64-11e7-8598-4cb0fb85db61.png)

