### PR TITLE
因为凤凰网的hs300的SZ399300数据出错,把hs300的代码换成了000300

### DIFF
--- a/tushare/__init__.py
+++ b/tushare/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 __author__ = 'Jimmy Liu'
 """
 for trading data

--- a/tushare/stock/cons.py
+++ b/tushare/stock/cons.py
@@ -13,7 +13,7 @@ K_TYPE = {'D': 'akdaily', 'W': 'akweekly', 'M': 'akmonthly'}
 TT_K_TYPE = {'D': 'day', 'W': 'week', 'M': 'month'}
 FQ_KEY = ['qfqday', 'hfqday', 'day']
 INDEX_LABELS = ['sh', 'sz', 'hs300', 'sz50', 'cyb', 'zxb', 'zx300', 'zh500']
-INDEX_LIST = {'sh': 'sh000001', 'sz': 'sz399001', 'hs300': 'sz399300',
+INDEX_LIST = {'sh': 'sh000001', 'sz': 'sz399001', 'hs300': 'sh000300',
               'sz50': 'sh000016', 'zxb': 'sz399005', 'cyb': 'sz399006', 'zx300': 'sz399008', 'zh500':'sh000905'}
 P_TYPE = {'http': 'http://', 'ftp': 'ftp://'}
 PAGE_NUM = [40, 60, 80, 100]


### PR DESCRIPTION
## bug原因

凤凰网数据 [hs300日线数据 hz399300](http://api.finance.ifeng.com/akdaily/?code=sz399300&type=last)
```json
["2017-02-02","3394.520","3450.180","3449.480","3393.600","631433.00","61.520","1.82","3,388.374","3,361.123","3,352.076","53,215,346.60","69,539,269.30","77,178,462.65"]
```
有一份2017-02-02,2017-05-30的交易数据,这两天实际上是没有交易的

## 解决方案:

把hs300的代码改成沪市的hs300 000300
 [hs300日线数据 sh000300](http://api.finance.ifeng.com/akdaily/?code=sh000300&type=last)
这个数据里面没有2017-02-02的数据

## 其他修改:

版本号升级到0.8.3