### PR TITLE
Update requirements.txt to resolve ModuleNotFoundErrors (#488)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ python-dateutil==2.6.1
 pytz==2017.2
 requests==2.18.4
 six==1.11.0
-tushare==0.9.8
 urllib3==1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,14 @@
-lxml == 3.4.4
+beautifulsoup4==4.6.0
+bs4==0.0.1
+certifi==2017.7.27.1
+chardet==3.0.4
+idna==2.6
+lxml==4.0.0
+numpy==1.13.3
+pandas==0.20.3
+python-dateutil==2.6.1
+pytz==2017.2
+requests==2.18.4
+six==1.11.0
+tushare==0.9.8
+urllib3==1.22


### PR DESCRIPTION
A number of ModuleNotFoundError errors occur when attempting to run setup.py on a clean python install.  After installing the necessary modules, this is my requirements.txt content generated from pip freeze. Contribution to #488