### PR TITLE
修复 get_nav_open 接口一次请求全部数据时报错 HTTP Error 500: Internal Server Error

### DIFF
--- a/tushare/fund/cons.py
+++ b/tushare/fund/cons.py
@@ -46,6 +46,8 @@ NAV_GRADING_T3 = {'all': '0', 'wjzq': '13',
                   'gp': '14', 'zs': '15', 'czzq': '16', 'jjzq': '17'}
 
 
+NAV_DEFAULT_PAGE = 1
+
 ##########################################################################
 # 基金数据列名
 
@@ -77,7 +79,7 @@ NAV_COLUMNS = {'open': NAV_OPEN_COLUMNS,
 ##########################################################################
 # 数据源URL
 SINA_NAV_COUNT_URL = '%s%s/fund_center/data/jsonp.php/IO.XSRV2.CallbackList[\'%s\']/NetValue_Service.%s?ccode=&type2=%s&type3=%s'
-SINA_NAV_DATA_URL = '%s%s/fund_center/data/jsonp.php/IO.XSRV2.CallbackList[\'%s\']/NetValue_Service.%s?page=1&num=%s&ccode=&type2=%s&type3=%s'
+SINA_NAV_DATA_URL = '%s%s/fund_center/data/jsonp.php/IO.XSRV2.CallbackList[\'%s\']/NetValue_Service.%s?page=%s&num=%s&ccode=&type2=%s&type3=%s'
 
 SINA_NAV_HISTROY_COUNT_URL = '%s%s/fundInfo/api/openapi.php/CaihuiFundInfoService.getNav?symbol=%s&datefrom=%s&dateto=%s'
 SINA_NAV_HISTROY_DATA_URL = '%s%s/fundInfo/api/openapi.php/CaihuiFundInfoService.getNav?symbol=%s&datefrom=%s&dateto=%s&num=%s'

--- a/tushare/fund/nav.py
+++ b/tushare/fund/nav.py
@@ -60,14 +60,20 @@ def get_nav_open(fund_type='all'):
                               ct.NAV_OPEN_T2[fund_type],
                               ct.NAV_OPEN_T3))
 
-        fund_df = _parse_fund_data(ct.SINA_NAV_DATA_URL %
-                                   (ct.P_TYPE['http'], ct.DOMAINS['vsf'],
-                                    ct.NAV_OPEN_KEY[fund_type],
-                                    ct.NAV_OPEN_API[fund_type],
-                                    nums,
-                                    ct.NAV_OPEN_T2[fund_type],
-                                    ct.NAV_OPEN_T3))
-        return fund_df
+        pages = 2  # 分两次请求数据
+        limit_cnt = int(nums/pages)+1   # 每次取的数量
+        fund_dfs = []
+        for page in range(1, pages+1):
+            fund_dfs = _parse_fund_data(ct.SINA_NAV_DATA_URL %
+                                       (ct.P_TYPE['http'], ct.DOMAINS['vsf'],
+                                        ct.NAV_OPEN_KEY[fund_type],
+                                        ct.NAV_OPEN_API[fund_type],
+                                        page,
+                                        limit_cnt,
+                                        ct.NAV_OPEN_T2[fund_type],
+                                        ct.NAV_OPEN_T3))
+
+        return pd.concat(fund_dfs, ignore_index=True)
 
 
 def get_nav_close(fund_type='all', sub_type='all'):
@@ -121,7 +127,9 @@ def get_nav_close(fund_type='all', sub_type='all'):
 
     fund_df = _parse_fund_data(ct.SINA_NAV_DATA_URL %
                                (ct.P_TYPE['http'], ct.DOMAINS['vsf'],
-                                ct.NAV_OPEN_KEY, ct.NAV_CLOSE_API, nums,
+                                ct.NAV_OPEN_KEY, ct.NAV_CLOSE_API, 
+                                ct.NAV_DEFAULT_PAGE,
+                                nums,
                                 ct.NAV_CLOSE_T2[fund_type],
                                 ct.NAV_CLOSE_T3[sub_type]),
                                'close')
@@ -173,7 +181,9 @@ def get_nav_grading(fund_type='all', sub_type='all'):
 
     fund_df = _parse_fund_data(ct.SINA_NAV_DATA_URL %
                                (ct.P_TYPE['http'], ct.DOMAINS['vsf'],
-                                ct.NAV_GRADING_KEY, ct.NAV_GRADING_API, nums,
+                                ct.NAV_GRADING_KEY, ct.NAV_GRADING_API, 
+                                ct.NAV_DEFAULT_PAGE,
+                                nums,
                                 ct.NAV_GRADING_T2[fund_type],
                                 ct.NAV_GRADING_T3[sub_type]),
                                'grading')


### PR DESCRIPTION
使用的时候，发现直接运行下面的代码获取基金的净值数据会报错：

```
import tushare as ts
ts.get_nav_open()
```

通过测试发现问题应该是因为一次获取的数据过多(6000+)，本次 PR 是修改为将数据通过两次获取，通过测试已经没有问题