### PR TITLE
get_notices(),通过soup进行内容解析，取代lxmll方法

### DIFF
--- a/tushare/stock/newsevent.py
+++ b/tushare/stock/newsevent.py
@@ -16,6 +16,7 @@ import lxml.html
 from lxml import etree
 import re
 import json
+import lxml.html.soupparser as soupparser
 try:
     from urllib.request import urlopen, Request
 except ImportError:
@@ -116,8 +117,15 @@ def get_notices(code=None, date=None):
     url = nv.NOTICE_INFO_URL%(ct.P_TYPE['http'], ct.DOMAINS['vsf'],
                               ct.PAGES['ntinfo'], symbol)
     url = url if date is None else '%s&gg_date=%s'%(url, date)
-    html = lxml.html.parse(url)
+    res_data = urlopen(url)
+    content = res_data.read()
+    html = soupparser.fromstring(content.decode('gbk'), features='html.parser')
+
     res = html.xpath('//table[@class=\"body_table\"]/tbody/tr')
+    if res[0].xpath('th/a/text()'):
+        pass
+    else:
+        return None
     data = []
     for td in res:
         title = td.xpath('th/a/text()')[0]


### PR DESCRIPTION
1.放弃lxml.html.parse()解析，新的方法先读取内容，通过soup进行解析
2.在for循环之前检查获取的内容，已经退市的个股，比如000991，获取不到公告内容就退出了，避免在for循环里面导致错误，增强代码的容错性。