### PR TITLE
修正一个python2/3运行过程中的过期函数keyword问题

### DIFF
--- a/tushare/stock/classifying.py
+++ b/tushare/stock/classifying.py
@@ -252,7 +252,7 @@ def get_zz500s():
 #         df.columns = ct.FOR_CLASSIFY_B_COLS
 #         df['code'] = df['code'].map(lambda x :str(x).zfill(6))
         wt = pd.read_excel(ct.HS300_CLASSIFY_URL_FTP%(ct.P_TYPE['ftp'], ct.DOMAINS['idxip'], 
-                                                   ct.PAGES['zz500wt']), parse_cols=[0, 3, 6])
+                                                   ct.PAGES['zz500wt']), usecols=[0, 3, 6])
         wt.columns = ct.FOR_CLASSIFY_W_COLS
         wt['code'] = wt['code'].map(lambda x :str(x).zfill(6))
         df = get_stock_basics()[['name']]


### PR DESCRIPTION
/usr/lib/python2.7/site-packages/tushare/stock/classifying.py:263: FutureWarning: the 'parse_cols' keyword is deprecated, use 'usecols' instead
  ct.PAGES['sz50b']), parse_cols=[0, 4, 5])