### PR TITLE
优化get_today_ticks，提高访问速度

### DIFF
--- a/tushare/stock/trading.py
+++ b/tushare/stock/trading.py
@@ -229,7 +229,7 @@ def get_sina_dd(code=None, date=None, vol=400, retry_count=3, pause=0.001):
     raise IOError(ct.NETWORK_URL_ERROR_MSG)
 
 
-def get_today_ticks(code=None, retry_count=3, pause=0.001):
+def get_today_ticks(code=None, retry_count=3, pause=0.001, all=True):
     """
         获取当日分笔明细数据
     Parameters
@@ -263,9 +263,10 @@ def get_today_ticks(code=None, retry_count=3, pause=0.001):
             data_str = json.dumps(data_str)
             data_str = json.loads(data_str)
             pages = len(data_str['detailPages'])
+            fixed_pages = 1 if all == False else pages
             data = pd.DataFrame()
             ct._write_head()
-            for pNo in range(1, pages+1):
+            for pNo in range(1, fixed_pages+1):
                 data = data.append(_today_ticks(symbol, date, pNo,
                                                 retry_count, pause), ignore_index=True)
         except Exception as er:


### PR DESCRIPTION
原有逻辑：每次获取所有的tick数据。缺点：在行情实时判断时需要等待较长时间，延迟太大
新的逻辑：增加默认参数all=True。优点：不影响原有接口。当传人all=False时，只获取第一页数据。通过裁剪内容，提高了接口响应速度。