### PR TITLE
Simplify with Unicode literals and feature detection

### DIFF
--- a/tushare/stock/reference.py
+++ b/tushare/stock/reference.py
@@ -75,35 +75,25 @@ def profit_data(year=2017, top=25,
     
 
 def _fun_divi(x):
-    if ct.PY3:
-        reg = re.compile(r'分红(.*?)元', re.UNICODE)
-        res = reg.findall(x)
-        return 0 if len(res)<1 else float(res[0]) 
-    else:
+    try:  # Python 2
         if isinstance(x, unicode):
-            s1 = unicode('分红','utf-8')
-            s2 = unicode('元','utf-8')
-            reg = re.compile(r'%s(.*?)%s'%(s1, s2), re.UNICODE)
+            reg = re.compile(r'%s(.*?)%s'%(u'分红', u'元'), re.UNICODE)
             res = reg.findall(x)
             return 0 if len(res)<1 else float(res[0])
         else:
             return 0
+    except NameError:  # Python 3
+        reg = re.compile(r'分红(.*?)元', re.UNICODE)
+        res = reg.findall(x)
+        return 0 if len(res)<1 else float(res[0]) 
 
 
 def _fun_into(x):
-    if ct.PY3:
-            reg1 = re.compile(r'转增(.*?)股', re.UNICODE)
-            reg2 = re.compile(r'送股(.*?)股', re.UNICODE)
-            res1 = reg1.findall(x)
-            res2 = reg2.findall(x)
-            res1 = 0 if len(res1)<1 else float(res1[0])
-            res2 = 0 if len(res2)<1 else float(res2[0])
-            return res1 + res2
-    else:
+    try:  # Python 2
         if isinstance(x, unicode):
-            s1 = unicode('转增','utf-8')
-            s2 = unicode('送股','utf-8')
-            s3 = unicode('股','utf-8')
+            s1 = u'转增'
+            s2 = u'送股'
+            s3 = u'股'
             reg1 = re.compile(r'%s(.*?)%s'%(s1, s3), re.UNICODE)
             reg2 = re.compile(r'%s(.*?)%s'%(s2, s3), re.UNICODE)
             res1 = reg1.findall(x)
@@ -113,6 +103,14 @@ def _fun_into(x):
             return res1 + res2
         else:
             return 0
+    except NameError:  # Python 3
+        reg1 = re.compile(r'转增(.*?)股', re.UNICODE)
+        reg2 = re.compile(r'送股(.*?)股', re.UNICODE)
+        res1 = reg1.findall(x)
+        res2 = reg2.findall(x)
+        res1 = 0 if len(res1)<1 else float(res1[0])
+        res2 = 0 if len(res2)<1 else float(res2[0])
+        return res1 + res2
     
     
 def _dist_cotent(year, pageNo, retry_count, pause):
@@ -447,7 +445,7 @@ def _newstocks(data, pageNo, retry_count, pause):
             df['code'] = df['code'].map(lambda x : str(x).zfill(6))
             df['xcode'] = df['xcode'].map(lambda x : str(x).zfill(6))
             res = html.xpath('//table[@class=\"table2\"]/tr[1]/td[1]/a/text()')
-            tag = '下一页' if ct.PY3 else unicode('下一页', 'utf-8')
+            tag = u'下一页'
             hasNext = True if tag in res else False 
             data = data.append(df, ignore_index=True)
             pageNo += 1


### PR DESCRIPTION
Use Unicode literals instead of repeated function calls to __unicode()__
```
$ python2
Python 2.7.15 [...]
>>> (unicode('元','utf-8') == u'元' and
...  unicode('转增','utf-8') == u'转增' and
...  unicode('送股','utf-8') == u'送股' and
...  unicode('股','utf-8') == u'股' and
...  unicode('下一页', 'utf-8') == u'下一页')
True
>>>
```
Also implement Python porting best practice [__use feature detection instead of version detection__](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

Resolves:
[flake8](http://flake8.pycqa.org) testing of https://github.com/waditu/tushare on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tushare/stock/reference.py:83:26: F821 undefined name 'unicode'
        if isinstance(x, unicode):
                         ^
./tushare/stock/reference.py:84:18: F821 undefined name 'unicode'
            s1 = unicode('分红','utf-8')
                 ^
./tushare/stock/reference.py:85:18: F821 undefined name 'unicode'
            s2 = unicode('元','utf-8')
                 ^
./tushare/stock/reference.py:103:26: F821 undefined name 'unicode'
        if isinstance(x, unicode):
                         ^
./tushare/stock/reference.py:104:18: F821 undefined name 'unicode'
            s1 = unicode('转增','utf-8')
                 ^
./tushare/stock/reference.py:105:18: F821 undefined name 'unicode'
            s2 = unicode('送股','utf-8')
                 ^
./tushare/stock/reference.py:106:18: F821 undefined name 'unicode'
            s3 = unicode('股','utf-8')
                 ^
./tushare/stock/reference.py:450:46: F821 undefined name 'unicode'
            tag = '下一页' if ct.PY3 else unicode('下一页', 'utf-8')
                                             ^
8     F821 undefined name 'unicode'
8
```