### PR TITLE
实现增量拉取当日历史分笔的接口

### DIFF
--- a/tushare/__init__.py
+++ b/tushare/__init__.py
@@ -15,7 +15,8 @@ from tushare.stock.trading import (get_hist_data, get_tick_data,
                                    get_k_data, get_day_all,
                                    get_sina_dd, bar, tick,
                                    get_markets, quotes,
-                                   get_instrument, reset_instrument)
+                                   get_instrument, reset_instrument,
+                                   get_today_ticks_incrementally)
 
 """
 for trading data


### PR DESCRIPTION
基于get_today_ticks 实现一个新的增量拉取的接口 get_today_ticks_incrementally。
由以前的一次全量拉取，改为可以实时增量拉取，对于需要实时更新数据的场景可提高数据获取速度，并且由于增量拉取使得每次拉取数据对sina页面访问次数低，可以实现高频增量更新数据而不会出现“HTTP Error 456”