### PR TITLE
Fix wrong beautifulsoup4 name in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests>=2.0.0
 lxml>=3.8.0
 simplejson>=3.16.0
 bs4>=0.0.1
-beautfulsoup4>=4.5.1
+beautifulsoup4>=4.5.1


### PR DESCRIPTION
The beautifulsoup4 in requirements.txt is wrong so it will fails to be installed.