### PR TITLE
修复调用read_excel传参异常

### DIFF
--- a/tushare/stock/classifying.py
+++ b/tushare/stock/classifying.py
@@ -263,7 +263,7 @@ def get_sz50s():
     """
     try:
         df = pd.read_excel(ct.SZ_CLASSIFY_URL_FTP%(ct.P_TYPE['http'], ct.DOMAINS['idx'], 
-                                                  ct.PAGES['sz50b']), parse_cols=[0, 4, 5])
+                                                  ct.PAGES['sz50b']), usecols=[0, 4, 5])
         df.columns = ct.FOR_CLASSIFY_B_COLS
         df['code'] = df['code'].map(lambda x :str(x).zfill(6))
         return df


### PR DESCRIPTION
调用get_sz50s错误如下：

- read_excel() got an unexpected keyword argument `parse_cols`
- parse_cols在pandas新版本中已废弃