### PR TITLE
Fixes pickle error

### DIFF
--- a/tushare/pro/client.py
+++ b/tushare/pro/client.py
@@ -48,4 +48,6 @@ class DataApi:
         return pd.DataFrame(items, columns=columns)
 
     def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError        
         return partial(self.query, name)


### PR DESCRIPTION
pickle时会去找有没有__getstate__和__setstate__，没有时再用自己默认的方法，而__getattr__里面现在会拿去当query名字，需要处理一下不然很多缓存的库遇到client对象都会出错