### PR TITLE
Update newsevent.py security problem

### DIFF
--- a/tushare/stock/newsevent.py
+++ b/tushare/stock/newsevent.py
@@ -49,8 +49,7 @@ def get_latest_news(top=None, show_content=False):
         data_str = urlopen(request, timeout=10).read()
         data_str = data_str.decode('GBK')
         data_str = data_str.split('=')[1][:-1]
-        data_str = eval(data_str, type('Dummy', (dict,), 
-                                       dict(__getitem__ = lambda s, n:n))())
+        data_str = data_str = eval(data_str, {"__builtins__": {}}, {"Dummy": type("Dummy", (dict,), {"__getitem__": lambda s, n: n})})
         data_str = json.dumps(data_str)
         data_str = json.loads(data_str)
         data_str = data_str['list']


### PR DESCRIPTION
源版本中的eval函数可能可以被绕过， 如果新闻数据输入一些饮用__import__内置的函数可能导致执行任何命令。使用任何使用tushare的用户遭受RCE攻击。ps：能给我一个token么- - ！